### PR TITLE
Remove files of remote dir before copying

### DIFF
--- a/.github/workflows/scp-example-workflow.yml
+++ b/.github/workflows/scp-example-workflow.yml
@@ -8,20 +8,31 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: checkout
+        uses: actions/checkout@v2
       - name: setup demo
         run: |
           mkdir test
           touch test/oof.txt
       - name: Copy folder content recursively to remote
-        uses: garygrossgarten/github-action-scp@release
+        uses: ./
         with:
           local: test
           remote: scp/directory
           host: ${{ secrets.HOST }}
           username: ${{ secrets.SSH_USER }}
           password: ${{ secrets.PASSWORD }}
+      - name: Copy folder content recursively to remote (clean directory)
+        uses: ./
+        with:
+          local: test
+          remote: scp/directory
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.SSH_USER }}
+          password: ${{ secrets.PASSWORD }}  
+          rmRemote: true  
       - name: Copy single file to remote
-        uses: garygrossgarten/github-action-scp@release
+        uses: ./
         with:
           local: test/oof.txt
           remote: scp/single/readme.md

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
   remote:
     description: "Path on the remote server to copy to."
     required: true
+  rmRemote:
+    description: "If it is a directory, remote files in it will be deleted before the copy is started."
+    required: false
   concurrency:
     description: "Number of concurrent file transfers."
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -9252,9 +9252,10 @@ function run() {
         const concurrency = +core.getInput('concurrency') || 1;
         const local = core.getInput('local');
         const remote = core.getInput('remote');
+        const rmRemote = !!core.getInput('rmRemote') || false;
         try {
             const ssh = yield connect(host, username, port, privateKey, password, passphrase, tryKeyboard);
-            yield scp(ssh, local, remote, concurrency, verbose, recursive);
+            yield scp(ssh, local, remote, concurrency, verbose, recursive, rmRemote);
             ssh.dispose();
         }
         catch (err) {
@@ -9286,11 +9287,14 @@ function connect(host = 'localhost', username, port = 22, privateKey, password, 
         return ssh;
     });
 }
-function scp(ssh, local, remote, concurrency, verbose = true, recursive = true) {
+function scp(ssh, local, remote, concurrency, verbose = true, recursive = true, rmRemote = false) {
     return __awaiter(this, void 0, void 0, function* () {
         console.log(`Starting scp Action: ${local} to ${remote}`);
         try {
             if (isDirectory(local)) {
+                if (rmRemote) {
+                    yield cleanDirectory(ssh, remote);
+                }
                 yield putDirectory(ssh, local, remote, concurrency, verbose, recursive);
             }
             else {
@@ -9335,6 +9339,20 @@ function putDirectory(ssh, local, remote, concurrency = 3, verbose = false, recu
                 console.log(`Retrying to copy ${failed.local} to ${failed.remote}.`);
                 yield putFile(ssh, failed.local, failed.remote, true);
             }));
+        }
+    });
+}
+function cleanDirectory(ssh, remote, verbose = true) {
+    return __awaiter(this, void 0, void 0, function* () {
+        try {
+            yield ssh.execCommand(`rm -rf ${remote}/*`);
+            if (verbose) {
+                console.log(`✔ Successfully deleted all files of ${remote}.`);
+            }
+        }
+        catch (error) {
+            console.error(`⚠️ An error happened:(.`, error.message, error.stack);
+            ssh.dispose();
         }
     });
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,9 +37,10 @@ function run() {
         const concurrency = +core.getInput('concurrency') || 1;
         const local = core.getInput('local');
         const remote = core.getInput('remote');
+        const rmRemote = !!core.getInput('rmRemote') || false;
         try {
             const ssh = yield connect(host, username, port, privateKey, password, passphrase, tryKeyboard);
-            yield scp(ssh, local, remote, concurrency, verbose, recursive);
+            yield scp(ssh, local, remote, concurrency, verbose, recursive, rmRemote);
             ssh.dispose();
         }
         catch (err) {
@@ -71,11 +72,14 @@ function connect(host = 'localhost', username, port = 22, privateKey, password, 
         return ssh;
     });
 }
-function scp(ssh, local, remote, concurrency, verbose = true, recursive = true) {
+function scp(ssh, local, remote, concurrency, verbose = true, recursive = true, rmRemote = false) {
     return __awaiter(this, void 0, void 0, function* () {
         console.log(`Starting scp Action: ${local} to ${remote}`);
         try {
             if (isDirectory(local)) {
+                if (rmRemote) {
+                    yield cleanDirectory(ssh, remote);
+                }
                 yield putDirectory(ssh, local, remote, concurrency, verbose, recursive);
             }
             else {
@@ -120,6 +124,20 @@ function putDirectory(ssh, local, remote, concurrency = 3, verbose = false, recu
                 console.log(`Retrying to copy ${failed.local} to ${failed.remote}.`);
                 yield putFile(ssh, failed.local, failed.remote, true);
             }));
+        }
+    });
+}
+function cleanDirectory(ssh, remote, verbose = true) {
+    return __awaiter(this, void 0, void 0, function* () {
+        try {
+            yield ssh.execCommand(`rm -rf ${remote}/*`);
+            if (verbose) {
+                console.log(`✔ Successfully deleted all files of ${remote}.`);
+            }
+        }
+        catch (error) {
+            console.error(`⚠️ An error happened:(.`, error.message, error.stack);
+            ssh.dispose();
         }
     });
 }


### PR DESCRIPTION
I have added an optional parameter that, if set, will delete existing files in the remote folder before the copy operation. 
That's useful for deploying hashed files etc...

Maybe you can take a look at it and test it.